### PR TITLE
Disabled end of map voting and increased timelimit

### DIFF
--- a/dist/tf/cfg/server.cfg
+++ b/dist/tf/cfg/server.cfg
@@ -89,7 +89,7 @@ mp_stalemate_enable "0"                                 //Enable/Disable stalema
 mp_stalemate_timelimit "240"                            // Timelimit (in seconds) of the stalemate round.
 mp_maxrounds "0"                                        //Number of rounds per map
 mp_winlimit "0"                                         //Number of wins per map
-mp_timelimit "15"                                       //time limit in minutes per map
+mp_timelimit "25"                                       //time limit in minutes per map
 tf_flag_caps_per_round "3"                              // Max number of flag captures per map
 
 // TF2 specific Gameplay and server settings
@@ -104,7 +104,7 @@ sv_vote_allow_spectators 0   //Allow spectators to participate in votes. Default
 sv_vote_issue_autobalance_allowed 1    //Allow a vote to disable autobalance to be called. Defaults to 1 (enabled).
 sv_vote_issue_extendlevel_allowed  1 //Allows a vote to be called to extend the current map, instead of going to the next one.
 sv_vote_issue_kick_allowed 0 //Allow kick votes to be called. Defaults to 0 (disabled).
-sv_vote_issue_nextlevel_allowed 1 //Allow the next level to be determined by vote. Defaults to 1 (enabled). If called during a round, the map will change on round end. Not at the end of the timelimit for the map. Disabling this also disables the automatic end of map vote.
+sv_vote_issue_nextlevel_allowed 0 //Allow the next level to be determined by vote. Defaults to 1 (enabled). If called during a round, the map will change on round end. Not at the end of the timelimit for the map. Disabling this also disables the automatic end of map vote.
 sv_vote_issue_nextlevel_allowextend 1 //Allow the next level vote to include an 'Extend' option. Defaults to 1 (enabled).
 sv_vote_issue_nextlevel_choicesmode 1 //Allow players to be presented with a list of lowest playtime maps to choose from. Defaults to 1 (enabled).
 sv_vote_issue_nextlevel_prevent_change 1// Not allowed to vote for a nextlevel if one has already been set. Defaults to 1 (enabled).


### PR DESCRIPTION
Disabled end of map voting to avoid visual bug and increased time limit to 25 for the hell of it.